### PR TITLE
feat: PID ファイル管理と stop コマンドの追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 /tmp/
 
 .DS_Store
+/_local/
+server.pid

--- a/lib/liquidbook.rb
+++ b/lib/liquidbook.rb
@@ -9,6 +9,7 @@ require_relative "liquidbook/mock_data"
 require_relative "liquidbook/filters/shopify_filters"
 require_relative "liquidbook/tags/section_tag"
 require_relative "liquidbook/tags/render_tag"
+require_relative "liquidbook/pid_manager"
 require_relative "liquidbook/theme_renderer"
 require_relative "liquidbook/server/app"
 

--- a/lib/liquidbook/cli.rb
+++ b/lib/liquidbook/cli.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "thor"
+require "fileutils"
 
 module Liquidbook
   class CLI < Thor
@@ -14,6 +15,10 @@ module Liquidbook
       theme_root = File.expand_path(options[:root])
       Liquidbook.root = theme_root
 
+      pid_manager = PidManager.new(theme_root: theme_root)
+      result = pid_manager.ensure_can_start!
+      warn "Warning: Removed stale PID file." if result == :stale_pid_cleaned
+
       puts "Liquidbook v#{VERSION}"
       puts "Theme root: #{theme_root}"
       puts "Server: http://#{options[:host]}:#{options[:port]}"
@@ -24,9 +29,31 @@ module Liquidbook
       puts "Found #{sections} sections, #{snippets} snippets"
       puts ""
 
+      pid_manager.write_pid
+      at_exit { pid_manager.remove_pid }
+
       Server::App.set :port, options[:port]
       Server::App.set :bind, options[:host]
       Server::App.run!
+    end
+
+    desc "stop", "Stop the running preview server"
+    option :root, type: :string, default: ".", aliases: "-r", desc: "Theme root directory"
+    def stop
+      theme_root = File.expand_path(options[:root])
+      pid_manager = PidManager.new(theme_root: theme_root)
+
+      case pid_manager.stop!
+      when :stopped
+        puts "Server stopped."
+      when :not_running
+        puts "Server is not running."
+      when :stale_pid_cleaned
+        puts "Server is not running (removed stale PID file)."
+      end
+    rescue Liquidbook::Error => e
+      warn "Error: #{e.message}"
+      exit 1
     end
 
     desc "render TEMPLATE", "Render a single template to stdout"

--- a/lib/liquidbook/pid_manager.rb
+++ b/lib/liquidbook/pid_manager.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+module Liquidbook
+  class PidManager
+    PID_FILE_NAME = "server.pid"
+
+    def initialize(theme_root:)
+      @theme_root = theme_root
+    end
+
+    def pid_file_path
+      File.join(@theme_root, ".liquid-preview", PID_FILE_NAME)
+    end
+
+    # Write the current process PID to the PID file
+    def write_pid
+      dir = File.dirname(pid_file_path)
+      FileUtils.mkdir_p(dir) unless File.directory?(dir)
+      File.write(pid_file_path, Process.pid.to_s)
+    end
+
+    # Read the PID from the PID file, returns nil if not found
+    def read_pid
+      return nil unless File.exist?(pid_file_path)
+
+      pid = File.read(pid_file_path).strip.to_i
+      pid.positive? ? pid : nil
+    end
+
+    # Remove the PID file
+    def remove_pid
+      File.delete(pid_file_path) if File.exist?(pid_file_path)
+    end
+
+    # Check if a process with the given PID is alive
+    def process_alive?(pid)
+      Process.kill(0, pid)
+      true
+    rescue Errno::ESRCH
+      false
+    rescue Errno::EPERM
+      # Process exists but we don't have permission to signal it
+      true
+    end
+
+    # Check the current state and ensure it's safe to start
+    # Returns :ok, :stale_pid_cleaned, or raises an error
+    def ensure_can_start!
+      pid = read_pid
+      return :ok if pid.nil?
+
+      if process_alive?(pid)
+        raise Error, "Server is already running (PID: #{pid}). Run `liquidbook stop` to stop it."
+      end
+
+      remove_pid
+      :stale_pid_cleaned
+    end
+
+    # Stop the running server process
+    # Returns :stopped, :not_running, or :stale_pid_cleaned
+    def stop!
+      pid = read_pid
+
+      if pid.nil?
+        return :not_running
+      end
+
+      unless process_alive?(pid)
+        remove_pid
+        return :stale_pid_cleaned
+      end
+
+      Process.kill("TERM", pid)
+      remove_pid
+      :stopped
+    rescue Errno::EPERM
+      raise Error, "Permission denied: cannot stop process (PID: #{pid})."
+    end
+  end
+end

--- a/spec/unit/pid_manager_spec.rb
+++ b/spec/unit/pid_manager_spec.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "tmpdir"
+
+RSpec.describe Liquidbook::PidManager do
+  let(:tmpdir) { Dir.mktmpdir }
+  let(:manager) { described_class.new(theme_root: tmpdir) }
+
+  after do
+    FileUtils.remove_entry(tmpdir)
+  end
+
+  describe "#pid_file_path" do
+    it "returns the path under .liquid-preview/" do
+      expect(manager.pid_file_path).to eq(File.join(tmpdir, ".liquid-preview", "server.pid"))
+    end
+  end
+
+  describe "#write_pid / #read_pid" do
+    it "writes and reads the current PID" do
+      manager.write_pid
+      expect(manager.read_pid).to eq(Process.pid)
+    end
+
+    it "creates the .liquid-preview directory if it does not exist" do
+      manager.write_pid
+      expect(File.directory?(File.join(tmpdir, ".liquid-preview"))).to be true
+    end
+  end
+
+  describe "#read_pid" do
+    it "returns nil when no PID file exists" do
+      expect(manager.read_pid).to be_nil
+    end
+
+    it "returns nil for an empty PID file" do
+      FileUtils.mkdir_p(File.join(tmpdir, ".liquid-preview"))
+      File.write(manager.pid_file_path, "")
+      expect(manager.read_pid).to be_nil
+    end
+  end
+
+  describe "#remove_pid" do
+    it "removes the PID file" do
+      manager.write_pid
+      manager.remove_pid
+      expect(File.exist?(manager.pid_file_path)).to be false
+    end
+
+    it "does nothing when no PID file exists" do
+      expect { manager.remove_pid }.not_to raise_error
+    end
+  end
+
+  describe "#process_alive?" do
+    it "returns true for the current process" do
+      expect(manager.process_alive?(Process.pid)).to be true
+    end
+
+    it "returns false for a non-existent PID" do
+      # Use a PID that is very unlikely to exist
+      expect(manager.process_alive?(99999999)).to be false
+    end
+  end
+
+  describe "#ensure_can_start!" do
+    context "when no PID file exists" do
+      it "returns :ok" do
+        expect(manager.ensure_can_start!).to eq(:ok)
+      end
+    end
+
+    context "when PID file has a stale PID" do
+      before do
+        FileUtils.mkdir_p(File.join(tmpdir, ".liquid-preview"))
+        File.write(manager.pid_file_path, "99999999")
+      end
+
+      it "removes the stale PID file and returns :stale_pid_cleaned" do
+        expect(manager.ensure_can_start!).to eq(:stale_pid_cleaned)
+        expect(File.exist?(manager.pid_file_path)).to be false
+      end
+    end
+
+    context "when PID file has a living process" do
+      before do
+        manager.write_pid
+      end
+
+      it "raises an error" do
+        expect { manager.ensure_can_start! }.to raise_error(
+          Liquidbook::Error, /already running/
+        )
+      end
+    end
+  end
+
+  describe "#stop!" do
+    context "when no PID file exists" do
+      it "returns :not_running" do
+        expect(manager.stop!).to eq(:not_running)
+      end
+    end
+
+    context "when PID file has a stale PID" do
+      before do
+        FileUtils.mkdir_p(File.join(tmpdir, ".liquid-preview"))
+        File.write(manager.pid_file_path, "99999999")
+      end
+
+      it "removes the stale PID file and returns :stale_pid_cleaned" do
+        expect(manager.stop!).to eq(:stale_pid_cleaned)
+        expect(File.exist?(manager.pid_file_path)).to be false
+      end
+    end
+
+    context "when PID file has a living process" do
+      let(:child_pid) { spawn("sleep 60") }
+
+      before do
+        FileUtils.mkdir_p(File.join(tmpdir, ".liquid-preview"))
+        File.write(manager.pid_file_path, child_pid.to_s)
+      end
+
+      after do
+        Process.wait(child_pid) rescue nil
+      end
+
+      it "sends SIGTERM and returns :stopped" do
+        expect(manager.stop!).to eq(:stopped)
+        expect(File.exist?(manager.pid_file_path)).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- `PidManager` クラスを新規作成し、PID ファイルの書き込み・読み取り・削除・stale 検出を実装
- `liquidbook stop` コマンドを追加し、稼働中のサーバーを停止可能に
- サーバー起動時に PID ファイルを書き出し、終了時（Ctrl+C 含む）に自動削除
- stale PID（プロセスが死んでいるのに残った PID ファイル）は起動時に自動クリーンアップ

## Test plan
- [ ] `bundle exec rspec` で全テスト通過を確認（PidManager のユニットテスト含む）
- [ ] `liquidbook server` 起動後、`.liquid-preview/server.pid` が作成されることを確認
- [ ] `liquidbook stop` でサーバーが停止し、PID ファイルが削除されることを確認
- [ ] Ctrl+C で停止時に PID ファイルが削除されることを確認
- [ ] PID ファイルが残った状態で再起動時に stale PID が自動クリーンアップされることを確認

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)