### PR TITLE
サイドバーに検索窓を追加する

### DIFF
--- a/lib/liquidbook/server/app.rb
+++ b/lib/liquidbook/server/app.rb
@@ -153,7 +153,7 @@ module Liquidbook
       def parse_overrides(params)
         overrides = {}
         params.each do |key, value|
-          next if %w[name splat captures].include?(key)
+          next if %w[name splat captures q].include?(key)
 
           overrides[key] = value
         end

--- a/lib/liquidbook/server/views/layout.erb
+++ b/lib/liquidbook/server/views/layout.erb
@@ -81,6 +81,9 @@
       border-left: 3px solid transparent;
       transition: background 0.15s, border-color 0.15s;
     }
+    .lp-sidebar-item[hidden] {
+      display: none;
+    }
     .lp-sidebar-item:hover {
       background: var(--lp-bg);
     }
@@ -94,6 +97,22 @@
       padding: 6px 16px 6px 24px;
       color: var(--lp-text-sub);
       font-style: italic;
+    }
+    .lp-sidebar-search {
+      padding: 8px 12px 12px;
+    }
+    .lp-sidebar-search-input {
+      width: 100%;
+      padding: 6px 8px;
+      border: 1px solid var(--lp-border);
+      border-radius: 4px;
+      font-size: 13px;
+      font-family: inherit;
+    }
+    .lp-sidebar-search-input:focus-visible {
+      border-color: var(--lp-accent);
+      outline: 2px solid var(--lp-accent);
+      outline-offset: -1px;
     }
 
     /* ── Main ── */
@@ -111,6 +130,9 @@
   </div>
 
   <nav class="lp-sidebar">
+    <div class="lp-sidebar-search">
+      <input type="text" class="lp-sidebar-search-input" placeholder="テンプレートを検索">
+    </div>
     <div class="lp-sidebar-group">
       <div class="lp-sidebar-heading">Sections</div>
       <% if @nav_sections.empty? %>
@@ -142,5 +164,21 @@
   <main class="lp-main">
     <%= yield %>
   </main>
+  <script>
+    document.querySelector('.lp-sidebar-search-input').addEventListener('input', function() {
+      const query = this.value.toLowerCase();
+      document.querySelectorAll('.lp-sidebar-group').forEach(function(group) {
+        const items = group.querySelectorAll('.lp-sidebar-item');
+        if (items.length === 0) return;
+        let visibleCount = 0;
+        items.forEach(function(item) {
+          const match = item.textContent.toLowerCase().includes(query);
+          item.hidden = !match;
+          if (match) visibleCount++;
+        });
+        group.hidden = visibleCount === 0;
+      });
+    });
+  </script>
 </body>
 </html>

--- a/lib/liquidbook/server/views/layout.erb
+++ b/lib/liquidbook/server/views/layout.erb
@@ -165,20 +165,48 @@
     <%= yield %>
   </main>
   <script>
-    document.querySelector('.lp-sidebar-search-input').addEventListener('input', function() {
-      const query = this.value.toLowerCase();
-      document.querySelectorAll('.lp-sidebar-group').forEach(function(group) {
-        const items = group.querySelectorAll('.lp-sidebar-item');
-        if (items.length === 0) return;
-        let visibleCount = 0;
-        items.forEach(function(item) {
-          const match = item.textContent.toLowerCase().includes(query);
-          item.hidden = !match;
-          if (match) visibleCount++;
+    (function() {
+      const input = document.querySelector('.lp-sidebar-search-input');
+      const links = document.querySelectorAll('.lp-sidebar-item');
+
+      function filterSidebar(query) {
+        document.querySelectorAll('.lp-sidebar-group').forEach(function(group) {
+          const items = group.querySelectorAll('.lp-sidebar-item');
+          if (items.length === 0) return;
+          let visibleCount = 0;
+          items.forEach(function(item) {
+            const match = item.textContent.toLowerCase().includes(query);
+            item.hidden = !match;
+            if (match) visibleCount++;
+          });
+          group.hidden = visibleCount === 0;
         });
-        group.hidden = visibleCount === 0;
+      }
+
+      function updateLinks(value) {
+        links.forEach(function(a) {
+          const url = new URL(a.href);
+          if (value) {
+            url.searchParams.set('q', value);
+          } else {
+            url.searchParams.delete('q');
+          }
+          a.href = url;
+        });
+      }
+
+      input.addEventListener('input', function() {
+        filterSidebar(this.value.toLowerCase());
+        updateLinks(this.value);
       });
-    });
+
+      var q = new URLSearchParams(location.search).get('q');
+      if (q) {
+        input.value = q;
+        filterSidebar(q.toLowerCase());
+        updateLinks(q);
+      }
+    })();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- サイドバー上部にテンプレート名で絞り込める検索入力欄を追加
- 検索クエリを `?q=` パラメータでURLに保持し、画面遷移後も検索状態を維持
- `parse_overrides` から `q` を除外し、Liquid レンダラへの意図しないパラメータ混入を防止

## Test plan
- [x] 検索窓に文字を入力し、Sections / Snippets がインクリメンタルにフィルタされること
- [x] 大文字・小文字を区別せず部分一致すること
- [x] 全アイテムが非表示のグループは見出しごと非表示になること
- [x] 検索状態でアイテムをクリックし、遷移先でも検索状態が維持されること
- [ ] 検索窓を空にすると全件表示に戻ること
- [ ] テンプレート0件のグループが検索操作で消えないこと

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)