### PR TITLE
chore: fixture 追加・サイドバー自動スクロール・フォーマット修正

### DIFF
--- a/lib/liquidbook/server/views/layout.erb
+++ b/lib/liquidbook/server/views/layout.erb
@@ -206,6 +206,12 @@
         filterSidebar(q.toLowerCase());
         updateLinks(q);
       }
+
+      const active = document.querySelector('.lp-sidebar-item.active');
+      if (active) {
+        const sidebar = document.querySelector('.lp-sidebar');
+        sidebar.scrollTop = active.offsetTop;
+      }
     })();
   </script>
 </body>

--- a/spec/fixtures/theme/sections/hero.liquid
+++ b/spec/fixtures/theme/sections/hero.liquid
@@ -1,6 +1,8 @@
 <section class="hero">
   <h1>{{ section.settings.title }}</h1>
-  {% if section.settings.show_button %}<button>Shop Now</button>{% endif %}
+  {% if section.settings.show_button -%}
+    <button>Shop Now</button>
+  {%- endif %}
   {% for block in section.blocks %}
     <img src="{{ block.settings.image_src }}">
   {% endfor %}
@@ -17,9 +19,7 @@
     {
       "type": "slide",
       "name": "Slide",
-      "settings": [
-        { "id": "image_src", "type": "text", "label": "Image", "default": "https://placehold.co/800x400" }
-      ]
+      "settings": [{ "id": "image_src", "type": "text", "label": "Image", "default": "https://placehold.co/800x400" }]
     }
   ]
 }

--- a/spec/fixtures/theme/snippets/badge.liquid
+++ b/spec/fixtures/theme/snippets/badge.liquid
@@ -1,0 +1,1 @@
+<span class="badge">{{ label }}</span>

--- a/spec/unit/theme_renderer_spec.rb
+++ b/spec/unit/theme_renderer_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Liquidbook::ThemeRenderer do
 
   describe "#snippets" do
     it "lists snippet names without extension" do
-      expect(renderer.snippets).to eq(%w[card])
+      expect(renderer.snippets).to eq(%w[badge card])
     end
   end
 


### PR DESCRIPTION
## Summary

- `@param` なしスニペットの fixture（badge.liquid）を追加
- サイドバーでアクティブなテンプレートまで自動スクロールするよう修正
- hero.liquid のフォーマットを整理

🤖 Generated with [Claude Code](https://claude.com/claude-code)