### PR TITLE
動作確認用の example テーマを追加する

### DIFF
--- a/.claude/setting.json
+++ b/.claude/setting.json
@@ -1,0 +1,24 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(ls:*)",
+      "Bash(grep:*)",
+      "Bash(find:*)",
+      "Bash(git add:*)",
+      "Bash(git commit -m ':*)",
+      "Bash(git push:*)",
+      "WebFetch(domain:guides.rubygems.org)"
+    ],
+    "deny": [
+      "Bash(rm -rf /)",
+      "Bash(rm -rf ~)",
+      "Bash(*--force*push*)",
+      "Bash(*push --force*)",
+      "Bash(*push -f*)",
+      "Bash(curl:*)",
+      "Read(./.env)",
+      "Read(./.env.*)",
+      "Read(./secrets/**)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 .DS_Store
 /_local/
 server.pid
+.claude/settings.local.json

--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ cd liquidbook
 bin/setup
 ```
 
+Run the preview server against the bundled example theme:
+
+```bash
+bundle exec liquidbook server -r example
+```
+
 See [Release Process](docs/RELEASING.md) for how to publish a new version.
 
 ## License

--- a/example/.liquid-preview/config.yml
+++ b/example/.liquid-preview/config.yml
@@ -1,0 +1,2 @@
+head:
+  - ./assets/styles.css

--- a/example/.liquid-preview/mocks.yml
+++ b/example/.liquid-preview/mocks.yml
@@ -1,0 +1,3 @@
+product:
+  title: "Sample Product"
+  price: 2500

--- a/example/assets/styles.css
+++ b/example/assets/styles.css
@@ -1,0 +1,80 @@
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  color: #333;
+}
+
+.hero {
+  text-align: center;
+  padding: 3rem 1rem;
+  background: #f8f8f8;
+}
+
+.hero h1 {
+  margin: 0 0 0.5rem;
+  font-size: 2rem;
+}
+
+.hero p {
+  margin: 0 0 1.5rem;
+  color: #666;
+}
+
+.hero__button {
+  display: inline-block;
+  padding: 0.75rem 1.5rem;
+  background: #333;
+  color: #fff;
+  text-decoration: none;
+  border-radius: 4px;
+}
+
+.hero__slide img {
+  max-width: 100%;
+  height: auto;
+  margin-top: 1.5rem;
+}
+
+.featured-collection {
+  padding: 2rem 1rem;
+}
+
+.featured-collection h2 {
+  margin: 0 0 1rem;
+  font-size: 1.5rem;
+}
+
+.featured-collection__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.product-card {
+  border: 1px solid #e0e0e0;
+  border-radius: 4px;
+  padding: 1rem;
+}
+
+.product-card--featured {
+  border-color: #333;
+}
+
+.product-card__title {
+  margin: 0 0 0.5rem;
+  font-size: 1rem;
+}
+
+.product-card__price {
+  color: #666;
+}
+
+.badge {
+  display: inline-block;
+  margin-top: 0.5rem;
+  padding: 0.25rem 0.5rem;
+  background: #333;
+  color: #fff;
+  font-size: 0.75rem;
+  border-radius: 2px;
+}

--- a/example/sections/featured-collection.liquid
+++ b/example/sections/featured-collection.liquid
@@ -1,0 +1,30 @@
+<section class="featured-collection">
+  <h2>{{ section.settings.title }}</h2>
+  <div class="featured-collection__grid">
+    {% for block in section.blocks %}
+      {% if block.type == "product" %}
+        {% render 'product-card', title: block.settings.title, price: block.settings.price, featured: block.settings.featured %}
+      {% endif %}
+    {% endfor %}
+  </div>
+</section>
+
+{% schema %}
+{
+  "name": "Featured collection",
+  "settings": [
+    { "id": "title", "type": "text", "label": "Heading", "default": "Featured products" }
+  ],
+  "blocks": [
+    {
+      "type": "product",
+      "name": "Product",
+      "settings": [
+        { "id": "title", "type": "text", "label": "Product name", "default": "Example product" },
+        { "id": "price", "type": "text", "label": "Price", "default": "1980" },
+        { "id": "featured", "type": "checkbox", "label": "Featured", "default": false }
+      ]
+    }
+  ]
+}
+{% endschema %}

--- a/example/sections/hero.liquid
+++ b/example/sections/hero.liquid
@@ -1,0 +1,39 @@
+<section class="hero">
+  <h1>{{ section.settings.heading }}</h1>
+  <p>{{ section.settings.subheading }}</p>
+  {% if section.settings.show_button -%}
+    <a class="hero__button" href="{{ section.settings.button_link }}">
+      {{ section.settings.button_label }}
+    </a>
+  {%- endif %}
+  {% for block in section.blocks %}
+    {% if block.type == "slide" %}
+      <div class="hero__slide">
+        <img src="{{ block.settings.image }}" alt="{{ block.settings.alt }}">
+      </div>
+    {% endif %}
+  {% endfor %}
+</section>
+
+{% schema %}
+{
+  "name": "Hero banner",
+  "settings": [
+    { "id": "heading", "type": "text", "label": "Heading", "default": "Welcome to our store" },
+    { "id": "subheading", "type": "textarea", "label": "Subheading", "default": "Discover our latest collection" },
+    { "id": "show_button", "type": "checkbox", "label": "Show button", "default": true },
+    { "id": "button_label", "type": "text", "label": "Button label", "default": "Shop now" },
+    { "id": "button_link", "type": "url", "label": "Button link", "default": "/collections/all" }
+  ],
+  "blocks": [
+    {
+      "type": "slide",
+      "name": "Slide",
+      "settings": [
+        { "id": "image", "type": "text", "label": "Image URL", "default": "https://placehold.co/1200x400" },
+        { "id": "alt", "type": "text", "label": "Alt text", "default": "Hero image" }
+      ]
+    }
+  ]
+}
+{% endschema %}

--- a/example/snippets/badge.liquid
+++ b/example/snippets/badge.liquid
@@ -1,0 +1,5 @@
+{% comment %}
+  @param {String} label [New] - Badge text
+{% endcomment %}
+
+<span class="badge">{{ label }}</span>

--- a/example/snippets/product-card.liquid
+++ b/example/snippets/product-card.liquid
@@ -1,0 +1,13 @@
+{% comment %}
+  @param {String} title [Product name] - Product title
+  @param {String} price [1980] - Price
+  @param {Boolean} featured [false] - Show featured badge
+{% endcomment %}
+
+<div class="product-card{% if featured %} product-card--featured{% endif %}">
+  <h3 class="product-card__title">{{ title }}</h3>
+  <span class="product-card__price">{{ price | money }}</span>
+  {% if featured %}
+    {% render 'badge', label: "Featured" %}
+  {% endif %}
+</div>

--- a/liquidbook.gemspec
+++ b/liquidbook.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.files = IO.popen(%w[git ls-files -z], chdir: __dir__, err: IO::NULL) do |ls|
     ls.readlines("\x0", chomp: true).reject do |f|
       (f == gemspec) ||
-        f.start_with?(*%w[bin/ test/ spec/ features/ .git appveyor Gemfile])
+        f.start_with?(*%w[bin/ test/ spec/ features/ example/ .git appveyor Gemfile])
     end
   end
   spec.bindir = "exe"


### PR DESCRIPTION
## Summary
- テスト用 `spec/fixtures/theme` とは別に、開発時の動作確認・デモ用テーマを `example/` に分離
- gemspec の除外パターンに `example/` を追加し gem には含めない
- README の Development セクションに `bundle exec liquidbook server -r example` を追記
- Claude Code のプロジェクト設定を追加（`.claude/settings.local.json` は gitignore）

Closes #28

## Test plan
- [x] `bundle exec liquidbook server -r example` でサーバーが起動し、sections 2 / snippets 2 が表示される
- [x] `bundle exec rspec` が全件パスする
- [ ] `gem build liquidbook.gemspec` で生成される gem に `example/` が含まれない

🤖 Generated with [Claude Code](https://claude.com/claude-code)