### PR TITLE
feat: スニペットのパラメータ更新をクエリパラメータ方式に変更する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Snippet parameter form now submits via GET with query parameters (page navigation) instead of a JS-driven POST that swapped innerHTML; the Rendered HTML view stays in sync and preview state is bookmarkable/shareable via URL
+
+### Removed
+
+- `POST /api/render/:type/:name` and `GET /api/render/:type/:name` endpoints, along with the 1.5s live-reload polling that depended on them
+
 ## [0.1.1] - 2026-04-09
 
 ### Added

--- a/lib/liquidbook/server/app.rb
+++ b/lib/liquidbook/server/app.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 require "sinatra/base"
-require "json"
 
 module Liquidbook
   module Server
     class App < Sinatra::Base
+      RESERVED_QUERY_KEYS = %w[name splat captures q].freeze
+
       set :views, File.expand_path("views", __dir__)
       set :public_folder, -> { File.join(Liquidbook.root, "assets") }
 
@@ -49,7 +50,6 @@ module Liquidbook
           @name = name
           @type = "section"
           @schema = load_schema("sections", name)
-          @params = []
           erb :preview
         rescue Liquidbook::Error => e
           status 404
@@ -61,12 +61,13 @@ module Liquidbook
       get "/snippets/:name" do
         name = params[:name]
         begin
-          overrides = parse_overrides(params)
+          @form_params = renderer.snippet_params(name)
+          overrides = parse_overrides(params, @form_params)
           @rendered = renderer.render_snippet(name, overrides: overrides)
           @name = name
           @type = "snippet"
           @schema = {}
-          @params = renderer.snippet_params(name)
+          @form_params = with_overrides_applied(@form_params, overrides)
           erb :preview
         rescue Liquidbook::Error => e
           status 404
@@ -100,47 +101,6 @@ module Liquidbook
         end
       end
 
-      # API: re-render with params (for live reload + param editing)
-      post "/api/render/:type/:name" do
-        content_type :json
-        type = params[:type]
-        name = params[:name]
-
-        begin
-          body = JSON.parse(request.body.read) rescue {}
-          overrides = body["overrides"] || {}
-
-          html = case type
-                 when "sections" then renderer.render_section(name, overrides: overrides)
-                 when "snippets" then renderer.render_snippet(name, overrides: overrides)
-                 else raise Error, "Unknown type: #{type}"
-                 end
-          { html: html }.to_json
-        rescue Liquidbook::Error => e
-          status 404
-          { error: e.message }.to_json
-        end
-      end
-
-      # API: re-render (GET for live reload)
-      get "/api/render/:type/:name" do
-        content_type :json
-        type = params[:type]
-        name = params[:name]
-
-        begin
-          html = case type
-                 when "sections" then renderer.render_section(name)
-                 when "snippets" then renderer.render_snippet(name)
-                 else raise Error, "Unknown type: #{type}"
-                 end
-          { html: html }.to_json
-        rescue Liquidbook::Error => e
-          status 404
-          { error: e.message }.to_json
-        end
-      end
-
       private
 
       def load_schema(dir, name)
@@ -150,14 +110,56 @@ module Liquidbook
         SchemaParser.new(File.read(path)).parse
       end
 
-      def parse_overrides(params)
+      # Build override hash from query params, coercing types based on @param metadata.
+      # Strings (including Japanese / multibyte) pass through as Rack-decoded UTF-8.
+      def parse_overrides(params, params_meta = nil)
+        type_by_name = build_type_index(params_meta)
         overrides = {}
-        params.each do |key, value|
-          next if %w[name splat captures q].include?(key)
 
-          overrides[key] = value
+        params.each do |key, value|
+          next if RESERVED_QUERY_KEYS.include?(key)
+
+          overrides[key] = coerce_override(value, type_by_name[key])
         end
+
         overrides
+      end
+
+      def build_type_index(params_meta)
+        return {} unless params_meta
+
+        params_meta.each_with_object({}) { |p, h| h[p["name"]] = p["type"] }
+      end
+
+      def coerce_override(value, type)
+        case type
+        when "checkbox" then value.to_s != "false"
+        when "number" then coerce_number(value)
+        else value
+        end
+      end
+
+      def coerce_number(value)
+        str = value.to_s.strip
+        return str if str.empty?
+
+        Integer(str, 10)
+      rescue ArgumentError
+        begin
+          Float(str)
+        rescue ArgumentError
+          str
+        end
+      end
+
+      # Return a new params_meta list with each param's "default" replaced by the
+      # current override value, so the form re-renders with submitted values.
+      # Non-destructive: original hashes are preserved (snippet_params caching-safe).
+      def with_overrides_applied(params_meta, overrides)
+        params_meta.map do |p|
+          name = p["name"]
+          overrides.key?(name) ? p.merge("default" => overrides[name]) : p
+        end
       end
     end
   end

--- a/lib/liquidbook/server/views/preview.erb
+++ b/lib/liquidbook/server/views/preview.erb
@@ -38,22 +38,32 @@
   <div style="width: 320px; flex-shrink: 0; position: sticky; top: 64px;">
 
     <!-- Snippet @param editor -->
-    <% if @params && !@params.empty? %>
+    <% if @form_params && !@form_params.empty? %>
       <div style="background: var(--lp-surface); border: 1px solid var(--lp-border); border-radius: var(--lp-radius); padding: 16px; margin-bottom: 16px;">
         <h3 style="font-size: 14px; margin: 0 0 12px; color: var(--lp-text-sub);">Parameters</h3>
-        <form id="param-form">
-          <% @params.each do |param| %>
+        <form method="get" action="/snippets/<%= h(@name) %>" accept-charset="UTF-8">
+          <% if (sidebar_q = request.params["q"]) && !sidebar_q.empty? %>
+            <input type="hidden" name="q" value="<%= h(sidebar_q) %>">
+          <% end %>
+          <% @form_params.each do |param| %>
             <div style="margin-bottom: 12px;">
               <label style="display: block; font-size: 12px; font-weight: 500; margin-bottom: 4px;">
                 <%= h(param["name"]) %>
                 <span style="font-weight: normal; color: var(--lp-text-sub);"><%= h(param["description"]) %></span>
               </label>
               <% if param["type"] == "checkbox" %>
-                <input type="checkbox" name="<%= h(param["name"]) %>" <%= "checked" if param["default"] %> data-param>
+                <div style="display: flex; gap: 12px; font-size: 13px;">
+                  <label style="display: flex; align-items: center; gap: 4px;">
+                    <input type="radio" name="<%= h(param["name"]) %>" value="true" <%= "checked" if param["default"] %>> Yes
+                  </label>
+                  <label style="display: flex; align-items: center; gap: 4px;">
+                    <input type="radio" name="<%= h(param["name"]) %>" value="false" <%= "checked" unless param["default"] %>> No
+                  </label>
+                </div>
               <% elsif param["type"] == "number" %>
-                <input type="number" name="<%= h(param["name"]) %>" value="<%= h(param["default"]) %>" style="width: 100%; padding: 6px 8px; border: 1px solid var(--lp-border); border-radius: 4px; font-size: 13px;" data-param>
+                <input type="number" name="<%= h(param["name"]) %>" value="<%= h(param["default"]) %>" style="width: 100%; padding: 6px 8px; border: 1px solid var(--lp-border); border-radius: 4px; font-size: 13px;">
               <% else %>
-                <input type="text" name="<%= h(param["name"]) %>" value="<%= h(param["default"]) %>" style="width: 100%; padding: 6px 8px; border: 1px solid var(--lp-border); border-radius: 4px; font-size: 13px;" data-param>
+                <input type="text" name="<%= h(param["name"]) %>" value="<%= h(param["default"]) %>" style="width: 100%; padding: 6px 8px; border: 1px solid var(--lp-border); border-radius: 4px; font-size: 13px;">
               <% end %>
             </div>
           <% end %>
@@ -128,56 +138,4 @@
   function setWidth(w) {
     document.getElementById('preview-frame').style.maxWidth = w;
   }
-
-  // Param form → re-render via POST
-  const form = document.getElementById('param-form');
-  if (form) {
-    form.addEventListener('submit', async (e) => {
-      e.preventDefault();
-      const overrides = {};
-      form.querySelectorAll('[data-param]').forEach(el => {
-        if (el.type === 'checkbox') {
-          overrides[el.name] = el.checked;
-        } else if (el.type === 'number') {
-          overrides[el.name] = Number(el.value);
-        } else {
-          overrides[el.name] = el.value;
-        }
-      });
-
-      const type = '<%= @type == "section" ? "sections" : "snippets" %>';
-      const name = '<%= @name %>';
-      try {
-        const res = await fetch(`/api/render/${type}/${name}`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ overrides })
-        });
-        const data = await res.json();
-        if (data.html) {
-          document.getElementById('preview-frame').innerHTML = data.html;
-        }
-      } catch (err) {
-        console.error('Render error:', err);
-      }
-    });
-  }
-
-  // Live reload via polling (file changes)
-  (function() {
-    const type = '<%= @type == "section" ? "sections" : "snippets" %>';
-    const name = '<%= @name %>';
-    let lastHtml = null;
-
-    setInterval(async () => {
-      try {
-        const res = await fetch(`/api/render/${type}/${name}`);
-        const data = await res.json();
-        if (data.html && lastHtml !== null && data.html !== lastHtml) {
-          document.getElementById('preview-frame').innerHTML = data.html;
-        }
-        lastHtml = data.html;
-      } catch (e) {}
-    }, 1500);
-  })();
 </script>

--- a/spec/integration/server_spec.rb
+++ b/spec/integration/server_spec.rb
@@ -56,39 +56,51 @@ RSpec.describe Liquidbook::Server::App, type: :integration do
         expect(last_response.status).to eq(404)
       end
     end
-  end
 
-  # POST /api/render/:type/:name — 再レンダリング
-  describe "POST /api/render/:type/:name" do
-    it "returns JSON with rendered html for a section" do
-      payload = { overrides: {} }.to_json
-      post "/api/render/sections/hero", payload, "CONTENT_TYPE" => "application/json"
-      expect(last_response.status).to eq(200)
-      body = JSON.parse(last_response.body)
-      expect(body).to have_key("html")
-      expect(body["html"]).to include("hero")
-    end
+    context "with query parameter overrides" do
+      it "applies a string override to the rendered output" do
+        get "/snippets/card", title: "Query Title"
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to include("Query Title")
+      end
 
-    it "applies overrides to snippet rendering" do
-      payload = { overrides: { "title" => "API Title" } }.to_json
-      post "/api/render/snippets/card", payload, "CONTENT_TYPE" => "application/json"
-      expect(last_response.status).to eq(200)
-      body = JSON.parse(last_response.body)
-      expect(body["html"]).to include("API Title")
-    end
+      it "preserves multibyte (Japanese) string overrides" do
+        get "/snippets/card", title: "テスト商品"
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to include("テスト商品")
+      end
 
-    it "returns 404 for unknown type" do
-      post "/api/render/layouts/base", "{}", "CONTENT_TYPE" => "application/json"
-      expect(last_response.status).to eq(404)
-      body = JSON.parse(last_response.body)
-      expect(body).to have_key("error")
-    end
+      it "coerces number overrides to numeric values for filters" do
+        get "/snippets/card", price: "2980"
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to include("¥2980")
+      end
 
-    it "returns 404 for missing template" do
-      post "/api/render/sections/ghost", "{}", "CONTENT_TYPE" => "application/json"
-      expect(last_response.status).to eq(404)
-      body = JSON.parse(last_response.body)
-      expect(body["error"]).to include("ghost")
+      it "coerces checkbox value=true to true" do
+        get "/snippets/card", featured: "true"
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to include("card--featured")
+      end
+
+      it "coerces checkbox value=false to false" do
+        get "/snippets/card", featured: "false"
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).not_to include("card--featured")
+      end
+
+      it "preserves @param checkbox defaults when the key is absent" do
+        # The radio pair always sends a value when the form is submitted;
+        # absence means a non-form-submission (e.g. direct URL with only title).
+        get "/snippets/card", title: "Other"
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).not_to include("card--featured")
+      end
+
+      it "ignores the sidebar search q parameter when building overrides" do
+        get "/snippets/card", q: "card"
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to include("My Card")
+      end
     end
   end
 


### PR DESCRIPTION
## Summary

Issue #25 への対応。スニペットのパラメータ編集フォームを JS による POST API + innerHTML 書き換えから、クエリパラメータ付き GET ページ遷移に変更。Rendered HTML 表示が常に同期し、URL でプレビュー状態を共有可能になる。

## 変更内容

- **フォーム送信を `method=get` のページ遷移に変更**: `preview-frame` も `Rendered HTML` の `<pre>` も両方サーバーサイドで再描画される
- **`POST /api/render` / `GET /api/render` エンドポイントを廃止**、それに紐づく 1.5 秒間隔のライブリロードポーリング (`setInterval`) も削除
- **`parse_overrides` に型変換を追加**: snippet の `@param` 型情報 (`@form_params`) を見て checkbox は `value != "false"` で bool 化、number は Integer→Float fallback。文字列は Rack の UTF-8 デコードをそのまま通す（日本語対応）
- **checkbox UI を Yes/No 2 ラジオボタンに変更**: HTML フォームの「未チェック checkbox は送信されない」仕様を回避するため。`_form` のような hidden marker を導入せず、ラジオが必ず値を送る性質を利用
- **サイドバー検索の `q` パラメータをフォーム送信後も保持**: フォーム内に `hidden` input で `q` を引き回す
- **`@params` を `@form_params` にリネーム**: Sinatra 内部の `@params` と衝突するため
- **`with_overrides_applied` を非破壊的に実装**: `snippet_params` がキャッシュされても安全な `map` ベース

### 関連 Issue

- Closes #25
- Section の overrides 対応 (`section.settings.*` への注入) は別 issue #38 として分離

## Test plan

- [x] 全テストパス（156 examples）
  - GET クエリパラメータの override テスト追加（文字列 / 日本語 / Number / checkbox 3 パターン / `q` 除外）
  - 旧 POST API のテストは削除
- [ ] ブラウザで以下を確認:
  - [ ] フォーム送信時に Rendered HTML 表示が同期する
  - [ ] 日本語文字列が text input 経由で正しく渡る
  - [ ] checkbox の Yes/No ラジオが現在値を反映する
  - [ ] サイドバー検索の `q` パラメータがフォーム送信後も保持される
  - [ ] URL を直接ブックマークしてプレビュー状態を再現できる

🤖 Generated with [Claude Code](https://claude.com/claude-code)